### PR TITLE
replace use of logrus with logr

### DIFF
--- a/controllers/cnfcertificationsuiterun_controller.go
+++ b/controllers/cnfcertificationsuiterun_controller.go
@@ -36,8 +36,7 @@ import (
 	cnfcertificationsv1alpha1 "github.com/greyerof/cnf-certification-operator/api/v1alpha1"
 	cnfcertjob "github.com/greyerof/cnf-certification-operator/controllers/cnf-cert-job"
 	"github.com/greyerof/cnf-certification-operator/controllers/definitions"
-
-	"github.com/sirupsen/logrus"
+	controllerlogger "github.com/greyerof/cnf-certification-operator/controllers/logger"
 )
 
 var sideCarImage string
@@ -58,6 +57,8 @@ var (
 	certificationRuns map[certificationRun]string
 	// Holds an autoincremental CNF Cert Suite pod id
 	cnfRunPodID int
+	// sets controller's logger.
+	controllerLogger = controllerlogger.New(log.FromContext(context.TODO()))
 )
 
 const (
@@ -89,14 +90,14 @@ func (r *CnfCertificationSuiteRunReconciler) updateJobPhaseStatus(cnfrun *cnfcer
 	cnfrun.Status.Phase = status
 	err := r.Status().Update(context.Background(), cnfrun)
 	if err != nil {
-		logrus.Errorf("Error found while updating CnfCertificationSuiteRun's status: %s", err)
+		controllerLogger.Errorf("Error found while updating CnfCertificationSuiteRun's status: %w", err)
 	}
 }
 
 func (r *CnfCertificationSuiteRunReconciler) getJobRunTimeThreshold(timeoutStr string) time.Duration {
 	jobRunTimeThreshold, err := time.ParseDuration(timeoutStr)
 	if err != nil {
-		logrus.Info("Couldn't extarct job run timeout, setting default timeout.")
+		controllerLogger.Info("Couldn't extarct job run timeout, setting default timeout.")
 		return defaultCnfCertSuiteTimeout
 	}
 	return jobRunTimeThreshold
@@ -111,23 +112,23 @@ func (r *CnfCertificationSuiteRunReconciler) waitForCnfCertJobPodToComplete(ctx 
 	startTime := time.Now()
 	for {
 		if time.Since(startTime) > jobRunTimeThreshold {
-			logrus.Error("Time threshold reached, job did not complete")
+			controllerLogger.Error("Time threshold reached, job did not complete")
 			break
 		}
 		switch cnfCertJobPod.Status.Phase {
 		case corev1.PodSucceeded:
-			logrus.Info("Cnf job pod has completed successfully.")
+			controllerLogger.Info("Cnf job pod has completed successfully.")
 			return
 		case corev1.PodFailed:
-			logrus.Info("Cnf job pod has completed with failure.")
+			controllerLogger.Info("Cnf job pod has completed with failure.")
 			return
 		default:
-			logrus.Info("Cnf job pod is running. Current status: ", cnfCertJobPod.Status.Phase)
+			controllerLogger.Infof("Cnf job pod is running. Current status: %s", cnfCertJobPod.Status.Phase)
 			time.Sleep(checkInterval)
 		}
 		err := r.Get(ctx, cnfCertJobNamespacedName, cnfCertJobPod)
 		if err != nil {
-			logrus.Error("Error found while getting cnf cert job pod: ", err)
+			controllerLogger.Errorf("Error found while getting cnf cert job pod: %w", err)
 		}
 	}
 }
@@ -150,10 +151,10 @@ func (r *CnfCertificationSuiteRunReconciler) handleEndOfCnfCertSuiteRun(ctx cont
 	certSuiteExitStatus := r.getCertSuiteContainerExitStatus(cnfCertJobPod)
 	if certSuiteExitStatus == 0 {
 		r.updateJobPhaseStatus(cnfrun, "CertSuiteFinished")
-		logrus.Info("CNF Cert job has finished running.")
+		controllerLogger.Info("CNF Cert job has finished running.")
 	} else {
 		r.updateJobPhaseStatus(cnfrun, "CertSuiteError")
-		logrus.Info("CNF Cert job encountered an error. Exit status: ", certSuiteExitStatus)
+		controllerLogger.Info("CNF Cert job encountered an error. Exit status: ", certSuiteExitStatus)
 	}
 
 	r.updateRunCrStatusReportName(ctx, namespace, fmt.Sprintf("%s-report", cnfCertJobPod.Name), cnfrun)
@@ -168,14 +169,14 @@ func (r *CnfCertificationSuiteRunReconciler) waitForReportToBeCreated(ctx contex
 	var cnfreport cnfcertificationsv1alpha1.CnfCertificationSuiteReport
 	for err := r.Get(ctx, reportNamespacedName, &cnfreport); err != nil; {
 		if time.Since(startTime) > defaultCnfCertSuiteTimeout {
-			logrus.Error("Time threshold reached, report is not found")
+			controllerLogger.Error("Time threshold reached, report is not found")
 			break
 		}
-		logrus.Infof("Waiting for %s to be created...", reportNamespacedName.Name)
+		controllerLogger.Infof("Waiting for %s to be created...", reportNamespacedName.Name)
 		time.Sleep(checkInterval)
 		err = r.Get(ctx, reportNamespacedName, &cnfreport)
 	}
-	logrus.Infof("%s has been created", reportNamespacedName.Name)
+	controllerLogger.Infof("%s has been created", reportNamespacedName.Name)
 }
 
 func (r *CnfCertificationSuiteRunReconciler) updateRunCrStatusReportName(ctx context.Context, namespace, reportName string, cnfrun *cnfcertificationsv1alpha1.CnfCertificationSuiteRun) {
@@ -183,7 +184,7 @@ func (r *CnfCertificationSuiteRunReconciler) updateRunCrStatusReportName(ctx con
 	cnfrun.Status.ReportName = reportName
 	err := r.Status().Update(context.Background(), cnfrun)
 	if err != nil {
-		logrus.Errorf("Error found while updating CnfCertificationSuiteRun's status: %s", err)
+		controllerLogger.Errorf("Error found while updating CnfCertificationSuiteRun's status: %w", err)
 	}
 }
 
@@ -197,19 +198,18 @@ func (r *CnfCertificationSuiteRunReconciler) updateRunCrStatusReportName(ctx con
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.1/pkg/reconcile
 func (r *CnfCertificationSuiteRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
-	logrus.Infof("Reconciling CnfCertificationSuiteRun CRD.")
+	controllerLogger.Info("Reconciling CnfCertificationSuiteRun CRD.")
 
 	reqCertificationRun := certificationRun{name: req.Name, namespace: req.Namespace}
 
 	var cnfrun cnfcertificationsv1alpha1.CnfCertificationSuiteRun
 	if getErr := r.Get(ctx, req.NamespacedName, &cnfrun); getErr != nil {
-		logrus.Infof("CnfCertificationSuiteRun CR %s (ns %s) not found.", req.Name, req.NamespacedName)
+		controllerLogger.Infof("CnfCertificationSuiteRun CR %s (ns %s) not found.", req.Name, req.NamespacedName)
 		if podName, exist := certificationRuns[reqCertificationRun]; exist {
-			logrus.Infof("CnfCertificationSuiteRun has been deleted. Removing the associated CNF Cert job pod %v", podName)
+			controllerLogger.Infof("CnfCertificationSuiteRun has been deleted. Removing the associated CNF Cert job pod %v", podName)
 			deleteErr := r.Delete(context.TODO(), &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: req.Namespace}})
 			if deleteErr != nil {
-				logrus.Errorf("Failed to remove CNF Cert Job pod %s in namespace %s: %v", req.Name, req.Namespace, deleteErr)
+				controllerLogger.Errorf("Failed to remove CNF Cert Job pod %s in namespace %s: %w", req.Name, req.Namespace, deleteErr)
 			}
 			delete(certificationRuns, reqCertificationRun)
 		}
@@ -217,11 +217,11 @@ func (r *CnfCertificationSuiteRunReconciler) Reconcile(ctx context.Context, req 
 	}
 
 	if podName, exist := certificationRuns[reqCertificationRun]; exist {
-		logrus.Infof("There's a certification job pod=%v running already. Ignoring changes in CnfCertificationSuiteRun %v", podName, reqCertificationRun)
+		controllerLogger.Infof("There's a certification job pod=%v running already. Ignoring changes in CnfCertificationSuiteRun %v", podName, reqCertificationRun)
 		return ctrl.Result{}, nil
 	}
 
-	logrus.Infof("New CNF Certification Job run requested: %v", reqCertificationRun)
+	controllerLogger.Infof("New CNF Certification Job run requested: %v", reqCertificationRun)
 
 	cnfRunPodID++
 	podName := fmt.Sprintf("%s-%d", definitions.CnfCertPodNamePrefix, cnfRunPodID)
@@ -229,12 +229,12 @@ func (r *CnfCertificationSuiteRunReconciler) Reconcile(ctx context.Context, req 
 	// Store the new run & associated CNF Cert pod name
 	certificationRuns[reqCertificationRun] = podName
 
-	logrus.Infof("Running CNF Certification Suite container (job id=%d) with labels %q, log level %q and timeout: %q",
+	controllerLogger.Infof("Running CNF Certification Suite container (job id=%d) with labels %q, log level %q and timeout: %q",
 		cnfRunPodID, cnfrun.Spec.LabelsFilter, cnfrun.Spec.LogLevel, cnfrun.Spec.TimeOut)
 
 	// Launch the pod with the CNF Cert Suite container plus the sidecar container to fetch the results.
 	r.updateJobPhaseStatus(&cnfrun, "CreatingCertSuiteJob")
-	logrus.Info("Creating CNF Cert job pod")
+	controllerLogger.Info("Creating CNF Cert job pod")
 	config := cnfcertjob.NewConfig(
 		podName,
 		req.Namespace,
@@ -248,12 +248,12 @@ func (r *CnfCertificationSuiteRunReconciler) Reconcile(ctx context.Context, req 
 
 	err := r.Create(ctx, cnfCertJobPod)
 	if err != nil {
-		log.Log.Error(err, "Failed to create CNF Cert job pod")
+		controllerLogger.Errorf("Failed to create CNF Cert job pod: %w", err)
 		r.updateJobPhaseStatus(&cnfrun, "FailedToDeployCertSuitePod")
 		return ctrl.Result{}, nil
 	}
 	r.updateJobPhaseStatus(&cnfrun, "RunningCertSuite")
-	logrus.Info("Running CNF Cert job")
+	controllerLogger.Info("Running CNF Cert job")
 
 	go r.handleEndOfCnfCertSuiteRun(ctx, req.NamespacedName.Namespace, cnfCertJobPod, &cnfrun)
 	return ctrl.Result{}, nil
@@ -261,7 +261,7 @@ func (r *CnfCertificationSuiteRunReconciler) Reconcile(ctx context.Context, req 
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *CnfCertificationSuiteRunReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	logrus.Infof("Setting up CnfCertificationSuiteRunReconciler's manager.")
+	controllerLogger.Info("Setting up CnfCertificationSuiteRunReconciler's manager.")
 	certificationRuns = map[certificationRun]string{}
 
 	var found bool

--- a/controllers/logger/logger.go
+++ b/controllers/logger/logger.go
@@ -1,0 +1,30 @@
+package controllerlogger
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+)
+
+// This struct is a wrapper for default logr, to allow the use of formatted logs.
+type CollectorLogger struct {
+	logr.Logger
+}
+
+func New(l logr.Logger) CollectorLogger {
+	return CollectorLogger{l}
+}
+
+func (l *CollectorLogger) Infof(format string, args ...interface{}) {
+	formattedMsg := fmt.Sprintf(format, args...)
+	l.Info(formattedMsg)
+}
+
+func (l *CollectorLogger) Error(msg string, keysAndValues ...interface{}) {
+	l.Logger.Error(nil, msg, keysAndValues...)
+}
+
+func (l *CollectorLogger) Errorf(format string, args ...interface{}) {
+	formattedError := fmt.Errorf(format, args...)
+	l.Error(formattedError.Error())
+}

--- a/controllers/logger/logger.go
+++ b/controllers/logger/logger.go
@@ -1,30 +1,32 @@
 package controllerlogger
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // This struct is a wrapper for default logr, to allow the use of formatted logs.
-type CollectorLogger struct {
+type ControllerLogger struct {
 	logr.Logger
 }
 
-func New(l logr.Logger) CollectorLogger {
-	return CollectorLogger{l}
+func New() ControllerLogger {
+	return ControllerLogger{Logger: log.FromContext(context.TODO())}
 }
 
-func (l *CollectorLogger) Infof(format string, args ...interface{}) {
+func (l *ControllerLogger) Infof(format string, args ...interface{}) {
 	formattedMsg := fmt.Sprintf(format, args...)
 	l.Info(formattedMsg)
 }
 
-func (l *CollectorLogger) Error(msg string, keysAndValues ...interface{}) {
+func (l *ControllerLogger) Error(msg string, keysAndValues ...interface{}) {
 	l.Logger.Error(nil, msg, keysAndValues...)
 }
 
-func (l *CollectorLogger) Errorf(format string, args ...interface{}) {
+func (l *ControllerLogger) Errorf(format string, args ...interface{}) {
 	formattedError := fmt.Errorf(format, args...)
 	l.Error(formattedError.Error())
 }


### PR DESCRIPTION
- Replace use of logrus with logr, to avoid using two different loggers.
- Created a wrapper on top of logr struct in order to allow formatted logs - for convenient matters. 