### PR TITLE
pass Run CR's timeout field as env var to the container running test suites

### DIFF
--- a/controllers/cnf-cert-job/cnfcertjob.go
+++ b/controllers/cnf-cert-job/cnfcertjob.go
@@ -20,18 +20,20 @@ type Config struct {
 	CertSuiteConfigRunName string
 	LabelsFilter           string
 	LogLevel               string
+	TimeOut                string
 	ConfigMapName          string
 	PreflightSecretName    string
 	SideCarAppImage        string
 }
 
-func NewConfig(podName, namespace, certSuiteConfigRunName, labelsFilter, logLevel, configMapName, preflightSecretName, sideCarAppImage string) *Config {
+func NewConfig(podName, namespace, certSuiteConfigRunName, labelsFilter, logLevel, timeOut, configMapName, preflightSecretName, sideCarAppImage string) *Config {
 	return &Config{
 		PodName:                podName,
 		Namespace:              namespace,
 		CertSuiteConfigRunName: certSuiteConfigRunName,
 		LabelsFilter:           labelsFilter,
 		LogLevel:               logLevel,
+		TimeOut:                timeOut,
 		ConfigMapName:          configMapName,
 		PreflightSecretName:    preflightSecretName,
 		SideCarAppImage:        sideCarAppImage,
@@ -109,6 +111,10 @@ func New(config *Config) *corev1.Pod {
 						{
 							Name:  "TNF_NON_INTRUSIVE_ONLY",
 							Value: "true",
+						},
+						{
+							Name:  "TIMEOUT",
+							Value: config.TimeOut,
 						},
 					},
 					ImagePullPolicy: "Always",

--- a/controllers/cnfcertificationsuiterun_controller.go
+++ b/controllers/cnfcertificationsuiterun_controller.go
@@ -201,7 +201,6 @@ func (r *CnfCertificationSuiteRunReconciler) Reconcile(ctx context.Context, req 
 	logrus.Infof("Reconciling CnfCertificationSuiteRun CRD.")
 
 	reqCertificationRun := certificationRun{name: req.Name, namespace: req.Namespace}
-
 	var cnfrun cnfcertificationsv1alpha1.CnfCertificationSuiteRun
 	if getErr := r.Get(ctx, req.NamespacedName, &cnfrun); getErr != nil {
 		logrus.Infof("CnfCertificationSuiteRun CR %s (ns %s) not found.", req.Name, req.NamespacedName)
@@ -241,6 +240,7 @@ func (r *CnfCertificationSuiteRunReconciler) Reconcile(ctx context.Context, req 
 		cnfrun.Name,
 		cnfrun.Spec.LabelsFilter,
 		cnfrun.Spec.LogLevel,
+		cnfrun.Spec.TimeOut,
 		cnfrun.Spec.ConfigMapName,
 		cnfrun.Spec.PreflightSecretName,
 		sideCarImage)


### PR DESCRIPTION
Together with the modification of run-cnf-suites.sh  in cnf repo ([PR#1846](https://github.com/test-network-function/cnf-certification-test/pull/1846)), setting Run CR's timeout field as an env var in the container running the test suites, will allow modifying default timeout to the given.