### PR TITLE
Makefile updates to simplify operator test deployment.

### DIFF
--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -36,11 +36,6 @@ docker build --no-cache -t "${SIDECAR_IMG}" -f cnf-cert-sidecar/Dockerfile .
 # Local install kustomize app that is needed to edit/patch the kustomization.yaml
 make kustomize
 
-# step: Add env var to the controller's container to set the sidecar image app that was built right before
-pushd config/manager
-  ../../bin/kustomize edit add patch --kind Deployment --patch "[{\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/env/1\", \"value\": {\"name\": \"SIDECAR_APP_IMG\", \"value\": \"${SIDECAR_IMG}\"} }]"
-popd
-
 # step: Build docker image for the controller. This will use IMG pointing to local docker image for the controller, which
 #       will be pushed to kind with "docker load docker-image $IMG"
 make docker-build

--- a/scripts/ci/smoke_test.sh
+++ b/scripts/ci/smoke_test.sh
@@ -22,10 +22,7 @@ DEFAULT_CNF_CERTSUITE_OPERATOR_NAMESPACE="cnf-certsuite-operator"
 CNF_CERTSUITE_OPERATOR_NAMESPACE=${CNF_CERTSUITE_OPERATOR_NAMESPACE:-$DEFAULT_CNF_CERTSUITE_OPERATOR_NAMESPACE}
 
 # Load samples, patching the kustomization.yaml to include the configmap and the preflight dockerconfig.
-pushd config/samples
-  ../../bin/kustomize edit add resource "extra/cnf-certsuite-configmap.yaml"
-  ../../bin/kustomize edit add resource "extra/cnf-certsuite-preflight-secret.yaml"
-popd
+make deploy-samples
 
 # Apply/create the sample CR.
 oc kustomize config/samples | oc apply -f -


### PR DESCRIPTION
The (exported) env var SIDECAR_IMG should be set in order to deploy the operator using "make deploy".

Also, I added a "deploy-samples" target in the Makefile to simplify testing the operator.