### PR TITLE
OCP Deploy: removed certmanager dependency.

### DIFF
--- a/bundle/manifests/cnf-certifications.redhat.com_cnfcertificationsuiteruns.yaml
+++ b/bundle/manifests/cnf-certifications.redhat.com_cnfcertificationsuiteruns.yaml
@@ -6,6 +6,8 @@ metadata:
   creationTimestamp: null
   name: cnfcertificationsuiteruns.cnf-certifications.redhat.com
 spec:
+  conversion:
+    strategy: None
   group: cnf-certifications.redhat.com
   names:
     kind: CnfCertificationSuiteRun

--- a/bundle/manifests/cnf-certsuite-webhook-service_v1_service.yaml
+++ b/bundle/manifests/cnf-certsuite-webhook-service_v1_service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: tnf-op
+    app.kubernetes.io/instance: webhook-service
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: service
+    app.kubernetes.io/part-of: tnf-op
+  name: cnf-certsuite-webhook-service
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/bundle/manifests/tnf-op.clusterserviceversion.yaml
+++ b/bundle/manifests/tnf-op.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-01-25T07:40:11Z"
+    createdAt: "2024-02-28T14:55:50Z"
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: tnf-op.v0.0.1
@@ -168,6 +168,10 @@ spec:
                   initialDelaySeconds: 15
                   periodSeconds: 20
                 name: manager
+                ports:
+                - containerPort: 9443
+                  name: webhook-server
+                  protocol: TCP
                 readinessProbe:
                   httpGet:
                     path: /readyz
@@ -186,10 +190,19 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                volumeMounts:
+                - mountPath: /tmp/k8s-webhook-server/serving-certs
+                  name: cert
+                  readOnly: true
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: cnf-certsuite-controller-manager
               terminationGracePeriodSeconds: 10
+              volumes:
+              - name: cert
+                secret:
+                  defaultMode: 420
+                  secretName: webhook-server-cert
       permissions:
       - rules:
         - apiGroups:
@@ -223,6 +236,15 @@ spec:
           verbs:
           - create
           - patch
+        - apiGroups:
+          - ""
+          resources:
+          - configMaps
+          - secrets
+          verbs:
+          - get
+          - list
+          - watch
         - apiGroups:
           - ""
           resources:
@@ -310,3 +332,24 @@ spec:
   provider:
     name: RedHat
   version: 0.0.1
+  webhookdefinitions:
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: cnf-certsuite-controller-manager
+    failurePolicy: Fail
+    generateName: vcnfcertificationsuiterun.kb.io
+    rules:
+    - apiGroups:
+      - cnf-certifications.redhat.com
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - cnfcertificationsuiteruns
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-cnf-certifications-redhat-com-v1alpha1-cnfcertificationsuiterun

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -15,7 +15,7 @@ patchesStrategicMerge:
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-- patches/cainjection_in_cnfcertificationsuiteruns.yaml
+#- patches/cainjection_in_cnfcertificationsuiteruns.yaml
 #- patches/cainjection_in_cnfcertificationsuitereports.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 

--- a/config/crd/patches/webhook_in_cnfcertificationsuiteruns.yaml
+++ b/config/crd/patches/webhook_in_cnfcertificationsuiteruns.yaml
@@ -5,12 +5,4 @@ metadata:
   name: cnfcertificationsuiteruns.cnf-certifications.redhat.com
 spec:
   conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          namespace: system
-          name: webhook-service
-          path: /convert
-      conversionReviewVersions:
-      - v1
+    strategy: None

--- a/config/default/manual-deploy/kustomization.yaml
+++ b/config/default/manual-deploy/kustomization.yaml
@@ -13,15 +13,15 @@ namePrefix: cnf-certsuite-
 #  someName: someValue
 
 bases:
-- ../crd
-- ../rbac
-- ../manager
-- ../manifests/bases/cnfpod-permissions
+- ../../crd
+- ../../rbac
+- ../../manager
+- ../../manifests/bases/cnfpod-permissions
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-- ../webhook
+- ../../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-#- ../certmanager
+- ../../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
@@ -31,8 +31,6 @@ patchesStrategicMerge:
 # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
 
-
-
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 - manager_webhook_patch.yaml
@@ -40,34 +38,34 @@ patchesStrategicMerge:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-#- webhookcainjection_patch.yaml
+- webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-# - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-#   objref:
-#     kind: Certificate
-#     group: cert-manager.io
-#     version: v1
-#     name: serving-cert # this name should match the one in certificate.yaml
-#   fieldref:
-#     fieldpath: metadata.namespace
-# - name: CERTIFICATE_NAME
-#   objref:
-#     kind: Certificate
-#     group: cert-manager.io
-#     version: v1
-#     name: serving-cert # this name should match the one in certificate.yaml
-# - name: SERVICE_NAMESPACE # namespace of the service
-#   objref:
-#     kind: Service
-#     version: v1
-#     name: webhook-service
-#   fieldref:
-#     fieldpath: metadata.namespace
-# - name: SERVICE_NAME
-#   objref:
-#     kind: Service
-#     version: v1
-#     name: webhook-service
+- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+  fieldref:
+    fieldpath: metadata.namespace
+- name: CERTIFICATE_NAME
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+- name: SERVICE_NAMESPACE # namespace of the service
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service
+  fieldref:
+    fieldpath: metadata.namespace
+- name: SERVICE_NAME
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service

--- a/config/default/manual-deploy/manager_auth_proxy_patch.yaml
+++ b/config/default/manual-deploy/manager_auth_proxy_patch.yaml
@@ -1,0 +1,55 @@
+# This patch inject a sidecar container which is a HTTP proxy for the
+# controller manager, it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/arch
+                  operator: In
+                  values:
+                    - amd64
+                    - arm64
+                    - ppc64le
+                    - s390x
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
+      containers:
+      - name: kube-rbac-proxy
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - "ALL"
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=0"
+        ports:
+        - containerPort: 8443
+          protocol: TCP
+          name: https
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+      - name: manager
+        args:
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--leader-elect"

--- a/config/default/manual-deploy/manager_config_patch.yaml
+++ b/config/default/manual-deploy/manager_config_patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager

--- a/config/default/manual-deploy/manager_webhook_patch.yaml
+++ b/config/default/manual-deploy/manager_webhook_patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert

--- a/config/default/manual-deploy/webhookcainjection_patch.yaml
+++ b/config/default/manual-deploy/webhookcainjection_patch.yaml
@@ -1,0 +1,29 @@
+# This patch add annotation to admission webhook config and
+# the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
+# apiVersion: admissionregistration.k8s.io/v1
+# kind: MutatingWebhookConfiguration
+# metadata:
+#   labels:
+#     app.kubernetes.io/name: mutatingwebhookconfiguration
+#     app.kubernetes.io/instance: mutating-webhook-configuration
+#     app.kubernetes.io/component: webhook
+#     app.kubernetes.io/created-by: tnf-op
+#     app.kubernetes.io/part-of: tnf-op
+#     app.kubernetes.io/managed-by: kustomize
+#   name: mutating-webhook-configuration
+#   annotations:
+#     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/name: validatingwebhookconfiguration
+    app.kubernetes.io/instance: validating-webhook-configuration
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: tnf-op
+    app.kubernetes.io/part-of: tnf-op
+    app.kubernetes.io/managed-by: kustomize
+  name: validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)


### PR DESCRIPTION
By default, "make deploy" should be used to manually deploy the operator in clusters where the cert-manager is already installed, but, in order to not mix that config params with the ones for the OLM-based manifests, a new config/default/manual-deploy folder has been created. The CERTMANAGER sections have been uncommented there only.

This allows the make bundle && make bundle-build bundle-push targets to create the OLM-based bundle using the "config/default" folder without any cert-manager related field uncommented.