### PR TITLE
Fix for release workflow file.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,8 +27,8 @@ jobs:
       - name: Set release version output var depending on the trigger type.
         run: |
             if ${GITHUB_EVENT_NAME} == "workflow_dispatch"; then
-              echo "Manually triggered workflow to make release ${{ on.workflow_dispatch.inputs.version }}"
-              echo "::set-output name=release_tag::${{ on.workflow_dispatch.inputs.version }}"
+              echo "Manually triggered workflow to make release ${{ inputs.version }}"
+              echo "::set-output name=release_tag::${{ inputs.version }}"
             else
               echo "New release published: ${{ github.ref_name }}"
               echo "::set-output name=release_tag::${{ github.ref_name }}"


### PR DESCRIPTION
workflow_dispatch inputs are  used by means of the "inputs." prefix.

See:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-of-onworkflow_dispatchinputs