### PR TITLE
Release workflow: go version downgraded to 1.21.7

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,10 +55,10 @@ jobs:
           echo "  - Bundle     : ${BUNDLE_IMG}"
           echo "  - Catalog    : ${CATALOG_IMG}"
 
-      - name: Set up Go 1.22
+      - name: Set up Go 1.21
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.0
+          go-version: 1.21.7
 
       - name: Disable default go problem matcher
         run: echo "::remove-matcher owner=go::"

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
-	github.com/go-logr/logr v1.2.3 // indirect
+	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
@@ -59,13 +59,13 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.26.0 // indirect
+	k8s.io/api v0.26.0
 	k8s.io/apiextensions-apiserver v0.26.0 // indirect
 	k8s.io/component-base v0.26.0 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 // indirect
-	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect,nollint:typos
+	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect; indirect,nollint:typos
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,6 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
-github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -98,7 +96,6 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.19.14 h1:gm3vOOXfiuw5i9p5N9xJvfjvuofpyvLA9Wr6QfK5Fng=
 github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
@@ -159,7 +156,6 @@ github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
-github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
For some reason, the "make build" process won't build with go 1.22, so I've downgraded it to 1.21.7.

+ Added changes to go.mod/sum files made by "go mod tidy".

This is the error shown when compiling with go 1.22:
```
mkdir -p /home/greyerof/github/tnf-op/bin
test -s /home/greyerof/github/tnf-op/bin/controller-gen && /home/greyerof/github/tnf-op/bin/controller-gen --version | grep -q v0.11.1 || \
GOBIN=/home/greyerof/github/tnf-op/bin go install
sigs.k8s.io/controller-tools/cmd/controller-gen@v0.11.1 /home/greyerof/github/tnf-op/bin/controller-gen
rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer
dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xa0963e]

goroutine 107 [running]:
go/types.(*Checker).handleBailout(0xc0000e7600, 0xc000fb5d40)
        /usr/local/go/src/go/types/check.go:367 +0x88
panic({0xbc4180?, 0x12acc40?})
        /usr/local/go/src/runtime/panic.go:770 +0x132
go/types.(*StdSizes).Sizeof(0x0, {0xdbcbd8, 0x12b53a0})
        /usr/local/go/src/go/types/sizes.go:228 +0x31e
go/types.(*Config).sizeof(...)
        /usr/local/go/src/go/types/sizes.go:333
go/types.representableConst.func1({0xdbcbd8?, 0x12b53a0?})
        /usr/local/go/src/go/types/const.go:76 +0x9e
go/types.representableConst({0xdc2f50, 0x1281500}, 0xc0000e7600, 0x12b53a0, 0xc000fb54b0)
        /usr/local/go/src/go/types/const.go:92 +0x192
go/types.(*Checker).representation(0xc0000e7600, 0xc000ee5a80, 0x12b53a0)
        /usr/local/go/src/go/types/const.go:256 +0x65
go/types.(*Checker).implicitTypeAndValue(0xc0000e7600, 0xc000ee5a80, {0xdbcc00, 0xc000328bd0})
        /usr/local/go/src/go/types/expr.go:375 +0x30d
go/types.(*Checker).assignment(0xc0000e7600, 0xc000ee5a80, {0xdbcc00, 0xc000328bd0}, {0xc912e4, 0x14})
        /usr/local/go/src/go/types/assignments.go:52 +0x2e5
go/types.(*Checker).initConst(0xc0000e7600, 0xc000ec4660, 0xc000ee5a80)
        /usr/local/go/src/go/types/assignments.go:126 +0x336
go/types.(*Checker).constDecl(0xc0000e7600, 0xc000ec4660, {0xdbf848, 0xc001082160}, {0xdbf848, 0xc001082180}, 0x0)
        /usr/local/go/src/go/types/decl.go:490 +0x348
go/types.(*Checker).objDecl(0xc0000e7600, {0xdc8638, 0xc000ec4660}, 0x0)
        /usr/local/go/src/go/types/decl.go:191 +0xa49
go/types.(*Checker).packageObjects(0xc0000e7600)
        /usr/local/go/src/go/types/resolver.go:693 +0x4dd
go/types.(*Checker).checkFiles(0xc0000e7600, {0xc000efc060, 0x5, 0x5})
        /usr/local/go/src/go/types/check.go:408 +0x1a5
go/types.(*Checker).Files(...)
        /usr/local/go/src/go/types/check.go:372
sigs.k8s.io/controller-tools/pkg/loader.(*loader).typeCheck(0xc000359020, 0xc000367ea0)
        /home/greyerof/go/pkg/mod/sigs.k8s.io/controller-tools@v0.11.1/pkg/loader/loader.go:286
+0x36a
sigs.k8s.io/controller-tools/pkg/loader.(*Package).NeedTypesInfo(0xc000367ea0)
        /home/greyerof/go/pkg/mod/sigs.k8s.io/controller-tools@v0.11.1/pkg/loader/loader.go:99
+0x39
sigs.k8s.io/controller-tools/pkg/loader.(*TypeChecker).check(0xc000658ba0, 0xc000367ea0)
        /home/greyerof/go/pkg/mod/sigs.k8s.io/controller-tools@v0.11.1/pkg/loader/refs.go:268
+0x2b7
sigs.k8s.io/controller-tools/pkg/loader.(*TypeChecker).check.func1(0x54?)
        /home/greyerof/go/pkg/mod/sigs.k8s.io/controller-tools@v0.11.1/pkg/loader/refs.go:262
+0x53
created by sigs.k8s.io/controller-tools/pkg/loader.(*TypeChecker).check in goroutine 68
        /home/greyerof/go/pkg/mod/sigs.k8s.io/controller-tools@v0.11.1/pkg/loader/refs.go:260
+0x1c5
make: *** [Makefile:92: manifests] Error 2
```