### PR TITLE
Make targets to deploy the operator using OLM subscriptions.

### DIFF
--- a/config/samples/olm/catalogsource.yaml
+++ b/config/samples/olm/catalogsource.yaml
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: cnf-certsuite-operator-olm-catalog
+  namespace: cnf-certsuite-operator
+spec:
+  sourceType: grpc
+  image: quay.io/testnetworkfunction/cnf-certsuite-operator-catalog:v0.0.1
+  displayName: CNF Certification Suite OLM Test Catalog
+  publisher: RedHat.com
+  grpcPodConfig:
+    securityContextConfig: restricted

--- a/config/samples/olm/kustomization.yaml
+++ b/config/samples/olm/kustomization.yaml
@@ -1,0 +1,8 @@
+
+resources:
+- namespace.yaml
+- catalogsource.yaml
+- operatorgroup.yaml
+- subscription.yaml
+
+namespace: cnf-certsuite-operator

--- a/config/samples/olm/namespace.yaml
+++ b/config/samples/olm/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cnf-certsuite-operator

--- a/config/samples/olm/operatorgroup.yaml
+++ b/config/samples/olm/operatorgroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: my-group
+  namespace: cnf-certsuite-operator
+spec:
+  targetNamespaces:
+    - "cnf-certsuite-operator"

--- a/config/samples/olm/subscription.yaml
+++ b/config/samples/olm/subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cnf-certsuite-operator
+  namespace: cnf-certsuite-operator
+spec:
+  sourceNamespace: cnf-certsuite-operator
+  channel: alpha
+  name: tnf-op
+  source: cnf-certsuite-operator-olm-catalog


### PR DESCRIPTION
To install the operator in the defaulted "cnf-certsuite-operator" namespace:
```
make olm-install
```
Both the catalog container image and the namespace can be changed by means of env vars:
```
OLM_INSTALL_NAMESPACE=test \
OLM_INSTALL_IMG_CATALOG=quay.io/testnetworkfunction/cnf-certsuite-operator-catalog:v0.0.1 \
  make olm-install
```
In the Makefile, both vars are defaulted to:
```
OLM_INSTALL_IMG_CATALOG=quay.io/testnetworkfunction/cnf-certsuite-operator-catalog:latest
OLM_INSTALL_NAMESPACE=cnf-certsuite-operator
```
Since the catalog image points to the latest version, if we only want to change the installation namespace to "test-ns", we can just do:
```
OLM_INSTALL_NAMESPACE=test-ns make olm-install
```

To uninstall, just type "make olm-uninstall".