### PR TITLE
Run CR validation test workflow

### DIFF
--- a/.github/workflows/cnfcertificationsuiterun_validation_test.yaml
+++ b/.github/workflows/cnfcertificationsuiterun_validation_test.yaml
@@ -8,103 +8,103 @@ on:
   workflow_dispatch:
 
 jobs:
-    test:
-        name: Test CnfCertificationSuiteRun's validation
-        runs-on: ubuntu-latest
-        env:
-          SHELL: /bin/bash
+  test:
+    name: Test CnfCertificationSuiteRun's validation
+    runs-on: ubuntu-latest
+    env:
+      SHELL: /bin/bash
 
-        steps:
-          - name: Disable default go problem matcher
-            run: echo "::remove-matcher owner=go::"
-
-            # Restart docker using /mnt/docker-storage (sdb) instead of /var/lib/docker (sda).
-          - name: Make docker to use /mnt (sdb) for storage
-            run: |
-              df -h
-              lsblk
-              sudo mkdir /mnt/docker-storage
-              sudo jq '.  +={"data-root" : "/mnt/docker-storage"}' < /etc/docker/daemon.json > /tmp/docker-daemon.json
-              sudo cp /tmp/docker-daemon.json /etc/docker/daemon.json
-              cat /etc/docker/daemon.json
-              sudo systemctl restart docker
-              sudo ls -la /mnt/docker-storage
-
-          - name: Check out code into the Go module directory
-            uses: actions/checkout@v4
-            with:
-              ref: ${{ github.sha }}
-
-          - name: Build operator
-            run: ./scripts/ci/build.sh
-
-          - name: Removed unused docker images and go cache cleanup
-            run: |
-              df -h
-              docker rmi $(docker images -f "dangling=true" -q) || true
-              docker builder prune --all -f
-              go clean -modcache
-              df -h
-
-            # Create a Kind cluster for testing.
-          - name: Check out `cnf-certification-test-partner` repo
-            uses: actions/checkout@v4
-            with:
-              repository: test-network-function/cnf-certification-test-partner
-              path: cnf-certification-test-partner
-
-          - name: Bootstrap cluster, docker, and python
-            uses: nick-fields/retry@v2
-            with:
-              timeout_minutes: 5
-              max_attempts: 3
-              command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make bootstrap-cluster && make bootstrap-docker-ubuntu-local && make bootstrap-python-ubuntu-local
+    steps:
+      - name: Disable default go problem matcher
+        run: echo "::remove-matcher owner=go::"
 
         # Restart docker using /mnt/docker-storage (sdb) instead of /var/lib/docker (sda).
-        # This step needs to be done right after the partner repo's bootstrap scripts, as they
-        # overwrite the docker's daemon.json.
-          - name: Make docker to use /mnt (sdb) for storage
-            run: |
-              df -h
-              lsblk
-              sudo mkdir /mnt/docker-storage || true
-              sudo jq '.  +={"data-root" : "/mnt/docker-storage"}' < /etc/docker/daemon.json > /tmp/docker-daemon.json
-              sudo cp /tmp/docker-daemon.json /etc/docker/daemon.json
-              cat /etc/docker/daemon.json
-              sudo systemctl restart docker
-              sudo ls -la /mnt/docker-storage
+      - name: Make docker to use /mnt (sdb) for storage
+        run: |
+          df -h
+          lsblk
+          sudo mkdir /mnt/docker-storage
+          sudo jq '.  +={"data-root" : "/mnt/docker-storage"}' < /etc/docker/daemon.json > /tmp/docker-daemon.json
+          sudo cp /tmp/docker-daemon.json /etc/docker/daemon.json
+          cat /etc/docker/daemon.json
+          sudo systemctl restart docker
+          sudo ls -la /mnt/docker-storage
 
-          - name: Run 'make rebuild-cluster'
-            uses: nick-fields/retry@v2
-            env:
-              SKIP_PRELOAD_IMAGES: true
-            with:
-              timeout_minutes: 15
-              max_attempts: 3
-              command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make rebuild-cluster
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
 
-          - name: Run 'make install'
-            uses: nick-fields/retry@v2
-            env:
-              SKIP_PRELOAD_IMAGES: true
-            with:
-              timeout_minutes: 20
-              max_attempts: 3
-              command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make install
+      - name: Build operator
+        run: ./scripts/ci/build.sh
 
-          - name: Install cert-manager to cluster
-            run: kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml
+      - name: Removed unused docker images and go cache cleanup
+        run: |
+          df -h
+          docker rmi $(docker images -f "dangling=true" -q) || true
+          docker builder prune --all -f
+          go clean -modcache
+          df -h
 
-          - name: More cleanup
-            run: |
-              df -h
-              docker rmi $(docker images -f "dangling=true" -q) || true
-              docker builder prune --all -f
-              go clean -modcache
-              df -h
+        # Create a Kind cluster for testing.
+      - name: Check out `cnf-certification-test-partner` repo
+        uses: actions/checkout@v4
+        with:
+          repository: test-network-function/cnf-certification-test-partner
+          path: cnf-certification-test-partner
 
-          - name: Install operator in the Kind cluster
-            run: ./scripts/ci/deploy.sh
+      - name: Bootstrap cluster, docker, and python
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make bootstrap-cluster && make bootstrap-docker-ubuntu-local && make bootstrap-python-ubuntu-local
 
-          - name: Test CnfCertificationSuiteRun's validation
-            run: ./scripts/ci/cnfcertificationsuiterun_validation_test.sh
+    # Restart docker using /mnt/docker-storage (sdb) instead of /var/lib/docker (sda).
+    # This step needs to be done right after the partner repo's bootstrap scripts, as they
+    # overwrite the docker's daemon.json.
+      - name: Make docker to use /mnt (sdb) for storage
+        run: |
+          df -h
+          lsblk
+          sudo mkdir /mnt/docker-storage || true
+          sudo jq '.  +={"data-root" : "/mnt/docker-storage"}' < /etc/docker/daemon.json > /tmp/docker-daemon.json
+          sudo cp /tmp/docker-daemon.json /etc/docker/daemon.json
+          cat /etc/docker/daemon.json
+          sudo systemctl restart docker
+          sudo ls -la /mnt/docker-storage
+
+      - name: Run 'make rebuild-cluster'
+        uses: nick-fields/retry@v2
+        env:
+          SKIP_PRELOAD_IMAGES: true
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make rebuild-cluster
+
+      - name: Run 'make install'
+        uses: nick-fields/retry@v2
+        env:
+          SKIP_PRELOAD_IMAGES: true
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make install
+
+      - name: Install cert-manager to cluster
+        run: kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml
+
+      - name: More cleanup
+        run: |
+          df -h
+          docker rmi $(docker images -f "dangling=true" -q) || true
+          docker builder prune --all -f
+          go clean -modcache
+          df -h
+
+      - name: Install operator in the Kind cluster
+        run: ./scripts/ci/deploy.sh
+
+      - name: Test CnfCertificationSuiteRun's validation
+        run: ./scripts/ci/cnfcertificationsuiterun_validation_test.sh

--- a/.github/workflows/cnfcertificationsuiterun_validation_test.yaml
+++ b/.github/workflows/cnfcertificationsuiterun_validation_test.yaml
@@ -1,4 +1,4 @@
-name: Test CnfCertificationSuiteRun's validation
+name: Test CnfCertificationSuiteRun webhooks
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  validation:
     name: Test CnfCertificationSuiteRun's validation
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/cnfcertificationsuiterun_validation_test.yaml
+++ b/.github/workflows/cnfcertificationsuiterun_validation_test.yaml
@@ -1,0 +1,110 @@
+name: Test CnfCertificationSuiteRun's validation
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+    test:
+        name: Test CnfCertificationSuiteRun's validation
+        runs-on: ubuntu-latest
+        env:
+          SHELL: /bin/bash
+
+        steps:
+          - name: Disable default go problem matcher
+            run: echo "::remove-matcher owner=go::"
+
+            # Restart docker using /mnt/docker-storage (sdb) instead of /var/lib/docker (sda).
+          - name: Make docker to use /mnt (sdb) for storage
+            run: |
+              df -h
+              lsblk
+              sudo mkdir /mnt/docker-storage
+              sudo jq '.  +={"data-root" : "/mnt/docker-storage"}' < /etc/docker/daemon.json > /tmp/docker-daemon.json
+              sudo cp /tmp/docker-daemon.json /etc/docker/daemon.json
+              cat /etc/docker/daemon.json
+              sudo systemctl restart docker
+              sudo ls -la /mnt/docker-storage
+
+          - name: Check out code into the Go module directory
+            uses: actions/checkout@v4
+            with:
+              ref: ${{ github.sha }}
+
+          - name: Build operator
+            run: ./scripts/ci/build.sh
+
+          - name: Removed unused docker images and go cache cleanup
+            run: |
+              df -h
+              docker rmi $(docker images -f "dangling=true" -q) || true
+              docker builder prune --all -f
+              go clean -modcache
+              df -h
+
+            # Create a Kind cluster for testing.
+          - name: Check out `cnf-certification-test-partner` repo
+            uses: actions/checkout@v4
+            with:
+              repository: test-network-function/cnf-certification-test-partner
+              path: cnf-certification-test-partner
+
+          - name: Bootstrap cluster, docker, and python
+            uses: nick-fields/retry@v2
+            with:
+              timeout_minutes: 5
+              max_attempts: 3
+              command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make bootstrap-cluster && make bootstrap-docker-ubuntu-local && make bootstrap-python-ubuntu-local
+
+        # Restart docker using /mnt/docker-storage (sdb) instead of /var/lib/docker (sda).
+        # This step needs to be done right after the partner repo's bootstrap scripts, as they
+        # overwrite the docker's daemon.json.
+          - name: Make docker to use /mnt (sdb) for storage
+            run: |
+              df -h
+              lsblk
+              sudo mkdir /mnt/docker-storage || true
+              sudo jq '.  +={"data-root" : "/mnt/docker-storage"}' < /etc/docker/daemon.json > /tmp/docker-daemon.json
+              sudo cp /tmp/docker-daemon.json /etc/docker/daemon.json
+              cat /etc/docker/daemon.json
+              sudo systemctl restart docker
+              sudo ls -la /mnt/docker-storage
+
+          - name: Run 'make rebuild-cluster'
+            uses: nick-fields/retry@v2
+            env:
+              SKIP_PRELOAD_IMAGES: true
+            with:
+              timeout_minutes: 15
+              max_attempts: 3
+              command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make rebuild-cluster
+
+          - name: Run 'make install'
+            uses: nick-fields/retry@v2
+            env:
+              SKIP_PRELOAD_IMAGES: true
+            with:
+              timeout_minutes: 20
+              max_attempts: 3
+              command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make install
+
+          - name: Install cert-manager to cluster
+            run: kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml
+
+          - name: More cleanup
+            run: |
+              df -h
+              docker rmi $(docker images -f "dangling=true" -q) || true
+              docker builder prune --all -f
+              go clean -modcache
+              df -h
+
+          - name: Install operator in the Kind cluster
+            run: ./scripts/ci/deploy.sh
+
+          - name: Test CnfCertificationSuiteRun's validation
+            run: ./scripts/ci/cnfcertificationsuiterun_validation_test.sh

--- a/api/v1alpha1/cnfcertificationsuiterun_webhook.go
+++ b/api/v1alpha1/cnfcertificationsuiterun_webhook.go
@@ -145,7 +145,7 @@ func (r *CnfCertificationSuiteRun) validatePreflightSecret() error {
 	}
 
 	// Verify required field exists and that it's not empty
-	if value, exists := preflightSecret.Data["preflight_dockerconfig.json"]; !exists || value == nil {
+	if value, exists := preflightSecret.Data["preflight_dockerconfig.json"]; !exists || len(value) == 0 {
 		err := fmt.Errorf("preflight secret's 'preflight_dockerconfig.json' field must be set with a valid docker config json content")
 		logger.Error(err, "CnfCertificationSuiteRun's preflight secret is invalid",
 			configMapLoggerKey, r.Spec.ConfigMapName, namespaceLoggerKey, r.Namespace)

--- a/config/samples/validation-test/configmaps/configmap4.yaml
+++ b/config/samples/validation-test/configmaps/configmap4.yaml
@@ -1,0 +1,11 @@
+# Invalid ConfigMap for testing purposes.
+# Invalidation reason: 'tnf_config.yaml' field doesn't exist
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cnf-certsuite-invalid-config4
+  namespace: cnf-certsuite-operator
+data:
+  

--- a/config/samples/validation-test/configmaps/configmap5.yaml
+++ b/config/samples/validation-test/configmaps/configmap5.yaml
@@ -1,0 +1,11 @@
+# Invalid ConfigMap for testing purposes.
+# Invalidation reason: 'tnf_config.yaml' field is empty
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cnf-certsuite-invalid-config5
+  namespace: cnf-certsuite-operator
+data:
+  tnf_config.yaml: 

--- a/config/samples/validation-test/invalid_run1.yaml
+++ b/config/samples/validation-test/invalid_run1.yaml
@@ -1,0 +1,22 @@
+# Invalid CnfCertificationSuiteRun for testing purposes.
+# Invalidation reason: configMapName contains an empty string.
+
+apiVersion: cnf-certifications.redhat.com/v1alpha1
+kind: CnfCertificationSuiteRun
+metadata:
+  labels:
+    app.kubernetes.io/name: cnfcertificationsuiterun
+    app.kubernetes.io/instance: cnfcertificationsuiterun-sample
+    app.kubernetes.io/part-of: tnf-op
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: tnf-op
+  name: cnfcertificationsuiterun-invalid-sample1
+  namespace: cnf-certsuite-operator
+spec:
+  # TODO(user): Add fields here
+  labelsFilter: "observability"
+  logLevel: "info"
+  timeout: "2h"
+
+  configMapName: ""
+  preflightSecretName : "cnf-certsuite-preflight-dockerconfig"

--- a/config/samples/validation-test/invalid_run10.yaml
+++ b/config/samples/validation-test/invalid_run10.yaml
@@ -1,0 +1,21 @@
+# Invalid CnfCertificationSuiteRun for testing purposes.
+# Invalidation reason: unsupported loglevel.
+apiVersion: cnf-certifications.redhat.com/v1alpha1
+kind: CnfCertificationSuiteRun
+metadata:
+  labels:
+    app.kubernetes.io/name: cnfcertificationsuiterun
+    app.kubernetes.io/instance: cnfcertificationsuiterun-invalid-sample
+    app.kubernetes.io/part-of: tnf-op
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: tnf-op
+  name: cnfcertificationsuiterun-sample10
+  namespace: cnf-certsuite-operator
+spec:
+  # TODO(user): Add fields here
+  labelsFilter: "observability"
+  logLevel: "unsupported-log-level"
+  timeout: "2h"
+
+  configMapName: "cnf-certsuite-config"
+  preflightSecretName : "cnf-certsuite-preflight-dockerconfig"

--- a/config/samples/validation-test/invalid_run2.yaml
+++ b/config/samples/validation-test/invalid_run2.yaml
@@ -1,0 +1,24 @@
+# Invalid CnfCertificationSuiteRun for testing purposes.
+# Invalidation reason: configMapName not initialized.
+
+apiVersion: cnf-certifications.redhat.com/v1alpha1
+kind: CnfCertificationSuiteRun
+metadata:
+  labels:
+    app.kubernetes.io/name: cnfcertificationsuiterun
+    app.kubernetes.io/instance: cnfcertificationsuiterun-sample
+    app.kubernetes.io/part-of: tnf-op
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: tnf-op
+  name: cnfcertificationsuiterun-invalid-sample2
+  namespace: cnf-certsuite-operator
+spec:
+  # TODO(user): Add fields here
+  labelsFilter: "observability"
+  logLevel: "info"
+  timeout: "2h"
+
+  preflightSecretName : "cnf-certsuite-preflight-dockerconfig"
+
+---
+

--- a/config/samples/validation-test/invalid_run3.yaml
+++ b/config/samples/validation-test/invalid_run3.yaml
@@ -1,0 +1,22 @@
+# Invalid CnfCertificationSuiteRun for testing purposes.
+# Invalidation reason: Config map name doesn't exist in the current ns.
+
+apiVersion: cnf-certifications.redhat.com/v1alpha1
+kind: CnfCertificationSuiteRun
+metadata:
+  labels:
+    app.kubernetes.io/name: cnfcertificationsuiterun
+    app.kubernetes.io/instance: cnfcertificationsuiterun-invalid-sample
+    app.kubernetes.io/part-of: tnf-op
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: tnf-op
+  name: cnfcertificationsuiterun-sample3
+  namespace: cnf-certsuite-operator
+spec:
+  # TODO(user): Add fields here
+  labelsFilter: "observability"
+  logLevel: "info"
+  timeout: "2h"
+
+  configMapName: "non-exist-configmap"
+  preflightSecretName : "cnf-certsuite-preflight-dockerconfig"

--- a/config/samples/validation-test/invalid_run4.yaml
+++ b/config/samples/validation-test/invalid_run4.yaml
@@ -1,0 +1,22 @@
+# Invalid CnfCertificationSuiteRun for testing purposes.
+# Invalidation reason: config maps's data is empty.
+
+apiVersion: cnf-certifications.redhat.com/v1alpha1
+kind: CnfCertificationSuiteRun
+metadata:
+  labels:
+    app.kubernetes.io/name: cnfcertificationsuiterun
+    app.kubernetes.io/instance: cnfcertificationsuiterun-sample
+    app.kubernetes.io/part-of: tnf-op
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: tnf-op
+  name: cnfcertificationsuiterun-invalid-sample4
+  namespace: cnf-certsuite-operator
+spec:
+  # TODO(user): Add fields here
+  labelsFilter: "observability"
+  logLevel: "info"
+  timeout: "2h"
+
+  configMapName: "cnf-certsuite-invalid-config4"
+  preflightSecretName : "cnf-certsuite-preflight-dockerconfig"

--- a/config/samples/validation-test/invalid_run5.yaml
+++ b/config/samples/validation-test/invalid_run5.yaml
@@ -1,0 +1,22 @@
+# Invalid CnfCertificationSuiteRun for testing purposes.
+# Invalidation reason: configMapName 'tnf_config.yaml' field is empty.
+
+apiVersion: cnf-certifications.redhat.com/v1alpha1
+kind: CnfCertificationSuiteRun
+metadata:
+  labels:
+    app.kubernetes.io/name: cnfcertificationsuiterun
+    app.kubernetes.io/instance: cnfcertificationsuiterun-sample
+    app.kubernetes.io/part-of: tnf-op
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: tnf-op
+  name: cnfcertificationsuiterun-invalid-sample5
+  namespace: cnf-certsuite-operator
+spec:
+  # TODO(user): Add fields here
+  labelsFilter: "observability"
+  logLevel: "info"
+  timeout: "2h"
+
+  configMapName: "cnf-certsuite-invalid-config5"
+  preflightSecretName : "cnf-certsuite-preflight-dockerconfig"

--- a/config/samples/validation-test/invalid_run6.yaml
+++ b/config/samples/validation-test/invalid_run6.yaml
@@ -1,0 +1,22 @@
+# Invalid CnfCertificationSuiteRun for testing purposes.
+# Invalidation reason: preflightSecretName is an empty string.
+
+apiVersion: cnf-certifications.redhat.com/v1alpha1
+kind: CnfCertificationSuiteRun
+metadata:
+  labels:
+    app.kubernetes.io/name: cnfcertificationsuiterun
+    app.kubernetes.io/instance: cnfcertificationsuiterun-sample
+    app.kubernetes.io/part-of: tnf-op
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: tnf-op
+  name: cnfcertificationsuiterun-sample6
+  namespace: cnf-certsuite-operator
+spec:
+  # TODO(user): Add fields here
+  labelsFilter: "observability"
+  logLevel: "info"
+  timeout: "2h"
+
+  configMapName: "cnf-certsuite-config"
+  preflightSecretName : ""

--- a/config/samples/validation-test/invalid_run7.yaml
+++ b/config/samples/validation-test/invalid_run7.yaml
@@ -1,0 +1,22 @@
+# Invalid CnfCertificationSuiteRun for testing purposes.
+# Invalidation reason: Secret's name doesn't exist in the current ns.
+
+apiVersion: cnf-certifications.redhat.com/v1alpha1
+kind: CnfCertificationSuiteRun
+metadata:
+  labels:
+    app.kubernetes.io/name: cnfcertificationsuiterun
+    app.kubernetes.io/instance: cnfcertificationsuiterun-invalid-sample
+    app.kubernetes.io/part-of: tnf-op
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: tnf-op
+  name: cnfcertificationsuiterun-sample7
+  namespace: cnf-certsuite-operator
+spec:
+  # TODO(user): Add fields here
+  labelsFilter: "observability"
+  logLevel: "info"
+  timeout: "2h"
+
+  configMapName: "non-exist-secret"
+  preflightSecretName : "cnf-certsuite-preflight-dockerconfig"

--- a/config/samples/validation-test/invalid_run7.yaml
+++ b/config/samples/validation-test/invalid_run7.yaml
@@ -18,5 +18,5 @@ spec:
   logLevel: "info"
   timeout: "2h"
 
-  configMapName: "non-exist-secret"
-  preflightSecretName : "cnf-certsuite-preflight-dockerconfig"
+  configMapName: "cnf-certsuite-config"
+  preflightSecretName : "non-exist-secret"

--- a/config/samples/validation-test/invalid_run8.yaml
+++ b/config/samples/validation-test/invalid_run8.yaml
@@ -1,0 +1,22 @@
+# Invalid CnfCertificationSuiteRun for testing purposes.
+# Invalidation reason: Secret's 'preflight_dockerconfig.json' field is empty.
+
+apiVersion: cnf-certifications.redhat.com/v1alpha1
+kind: CnfCertificationSuiteRun
+metadata:
+  labels:
+    app.kubernetes.io/name: cnfcertificationsuiterun
+    app.kubernetes.io/instance: cnfcertificationsuiterun-invalid-sample
+    app.kubernetes.io/part-of: tnf-op
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: tnf-op
+  name: cnfcertificationsuiterun-sample8
+  namespace: cnf-certsuite-operator
+spec:
+  # TODO(user): Add fields here
+  labelsFilter: "observability"
+  logLevel: "info"
+  timeout: "2h"
+
+  configMapName: "cnf-certsuite-config"
+  preflightSecretName : "cnf-certsuite-invalid-preflight-dockerconfig8"

--- a/config/samples/validation-test/invalid_run9.yaml
+++ b/config/samples/validation-test/invalid_run9.yaml
@@ -1,0 +1,21 @@
+# Invalid CnfCertificationSuiteRun for testing purposes.
+# Invalidation reason: Secret's 'preflight_dockerconfig.json' field doesn't exist.
+apiVersion: cnf-certifications.redhat.com/v1alpha1
+kind: CnfCertificationSuiteRun
+metadata:
+  labels:
+    app.kubernetes.io/name: cnfcertificationsuiterun
+    app.kubernetes.io/instance: cnfcertificationsuiterun-invalid-sample
+    app.kubernetes.io/part-of: tnf-op
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: tnf-op
+  name: cnfcertificationsuiterun-sample9
+  namespace: cnf-certsuite-operator
+spec:
+  # TODO(user): Add fields here
+  labelsFilter: "observability"
+  logLevel: "info"
+  timeout: "2h"
+
+  configMapName: "cnf-certsuite-config"
+  preflightSecretName : "cnf-certsuite-invalid-preflight-dockerconfig9"

--- a/config/samples/validation-test/preflight_secrets/preflight_secret8.yaml
+++ b/config/samples/validation-test/preflight_secrets/preflight_secret8.yaml
@@ -1,0 +1,12 @@
+# Invalid preflight secret for testing purposes.
+# Invalidation reason: 'preflight_dockerconfig.json' field is empty
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cnf-certsuite-invalid-preflight-dockerconfig8
+  namespace: cnf-certsuite-operator
+type: Opaque
+data:
+  # Sample of empty content, base64-coded: '{ "auths": {} }'
+  preflight_dockerconfig.json: 

--- a/config/samples/validation-test/preflight_secrets/preflight_secret9.yaml
+++ b/config/samples/validation-test/preflight_secrets/preflight_secret9.yaml
@@ -1,0 +1,11 @@
+# Invalid preflight secret for testing purposes.
+# Invalidation reason: 'preflight_dockerconfig.json' field doesn't exist.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cnf-certsuite-invalid-preflight-dockerconfig9
+  namespace: cnf-certsuite-operator
+type: Opaque
+data:
+  # Sample of empty content, base64-coded: '{ "auths": {} }'

--- a/scripts/ci/cnfcertificationsuiterun_validation_test.sh
+++ b/scripts/ci/cnfcertificationsuiterun_validation_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# This script is testing the CnfCertificationSuiteRun CR validation proccess.
+# This script is testing the CnfCertificationSuiteRun CR validation process.
 # Invalid CRs are applied, and it is verified an error is returned.
 # Also a valid CR is applied, and it is verified no error is returned.
 #
@@ -18,7 +18,7 @@ global_error=0
 # Apply/create the valid sample CR.
 oc kustomize config/samples | oc apply -f -  && exit_statuses+=(0) || exit_statuses+=($?)
 
-# Inavlid configmap names
+# Invalid configmap names
 oc apply -f config/samples/validation-test/invalid_run1.yaml && exit_statuses+=(0) || exit_statuses+=($?)
 oc apply -f config/samples/validation-test/invalid_run2.yaml && exit_statuses+=(0) || exit_statuses+=($?)
 oc apply -f config/samples/validation-test/invalid_run3.yaml && exit_statuses+=(0) || exit_statuses+=($?)

--- a/scripts/ci/cnfcertificationsuiterun_validation_test.sh
+++ b/scripts/ci/cnfcertificationsuiterun_validation_test.sh
@@ -62,5 +62,8 @@ done
 
 # Check if any errors occurred
 if [ $global_error -eq 1 ]; then
+    echo "Error: unexpectable result from one of the tests"
     exit 1
+else
+    echo "All Tests have passed!"
 fi

--- a/scripts/ci/cnfcertificationsuiterun_validation_test.sh
+++ b/scripts/ci/cnfcertificationsuiterun_validation_test.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# This script is testing the CnfCertificationSuiteRun CR validation proccess.
+# Invalid CRs are applied, and it is verified an error is returned.
+# Also a valid CR is applied, and it is verified no error is returned.
+#
+
+# Bash settings: display (expanded) commands and fast exit on first error.
+set -o xtrace
+set -o errexit
+
+# Load samples, patching the kustomization.yaml to include the valid configmap and the valid preflight dockerconfig.
+make deploy-samples
+
+exit_statuses=()
+global_error=0
+
+# Apply/create the valid sample CR.
+oc kustomize config/samples | oc apply -f -  && exit_statuses+=(0) || exit_statuses+=($?)
+
+# Inavlid configmap names
+oc apply -f config/samples/validation-test/invalid_run1.yaml && exit_statuses+=(0) || exit_statuses+=($?)
+oc apply -f config/samples/validation-test/invalid_run2.yaml && exit_statuses+=(0) || exit_statuses+=($?)
+oc apply -f config/samples/validation-test/invalid_run3.yaml && exit_statuses+=(0) || exit_statuses+=($?)
+
+# Invalid configmaps content
+oc apply -f config/samples/validation-test/configmaps/configmap4.yaml
+oc apply -f config/samples/validation-test/invalid_run4.yaml && exit_statuses+=(0) || exit_statuses+=($?)
+oc apply -f config/samples/validation-test/configmaps/configmap5.yaml
+oc apply -f config/samples/validation-test/invalid_run5.yaml && exit_statuses+=(0) || exit_statuses+=($?)
+
+# Invalid preflight secret names
+oc apply -f config/samples/validation-test/invalid_run6.yaml && exit_statuses+=(0) || exit_statuses+=($?)
+oc apply -f config/samples/validation-test/invalid_run7.yaml && exit_statuses+=(0) || exit_statuses+=($?)
+
+# Invalid preflight secret content
+oc apply -f config/samples/validation-test/preflight_secrets/preflight_secret8.yaml
+oc apply -f config/samples/validation-test/invalid_run8.yaml && exit_statuses+=(0) || exit_statuses+=($?)
+oc apply -f config/samples/validation-test/preflight_secrets/preflight_secret9.yaml
+oc apply -f config/samples/validation-test/invalid_run9.yaml && exit_statuses+=(0) || exit_statuses+=($?)
+
+# Invalid log level
+oc apply -f config/samples/validation-test/invalid_run10.yaml && exit_statuses+=(0) || exit_statuses+=($?)
+
+# Check valid run CR exit status
+if [ "${exit_statuses[0]}" -eq 0 ]; then
+    echo "Test passed: valid run sample, has passed validation"
+else
+    global_error=1
+    echo "Error: valid run sample has failed validation"
+fi
+
+# Check invalid run CR's exit statuses
+for ((i=1; i<${#exit_statuses[@]}; i++)); do
+    if [ "${exit_statuses[i]}" -eq 0 ]; then
+        global_error=1
+        echo "Error: invalid_run$((i)) has passed validation"
+    else
+        echo "Test passed: invalid_run$((i)), has failed validation"
+    fi
+done
+
+# Check if any errors occurred
+if [ $global_error -eq 1 ]; then
+    exit 1
+fi


### PR DESCRIPTION
Workflow testing the run CR validation by applying run CR and checking their exit codes.
The following test cases are tested:
1. Valid run CR.
2. Invalid run 1: configMapName contains an empty string.
3. Invalid run 2: configMapName not initialized.
4. Invalid run 3: configMapName doesn't exist in the current ns.
5. Invalid run 4: config maps's data is empty.
6. Invalid run 5: configMapName 'tnf_config.yaml' field is empty.
7. Invalid run 6: preflightSecretName is an empty string.
8. Invalid run 7: Secret's name doesn't exist in the current ns.
9. Invalid run 8: Secret's 'preflight_dockerconfig.json' field is empty.
10. Invalid run 9: Secret's data is empty.
11. Invalid run 10: unsupported loglevel.