### PR TITLE
Github workflows: remove partner repo checkout before deploying the operator

### DIFF
--- a/.github/workflows/cnfcertificationsuiterun_validation_test.yaml
+++ b/.github/workflows/cnfcertificationsuiterun_validation_test.yaml
@@ -101,6 +101,7 @@ jobs:
           docker rmi $(docker images -f "dangling=true" -q) || true
           docker builder prune --all -f
           go clean -modcache
+          rm -rf ${GITHUB_WORKSPACE}/cnf-certification-test-partner
           df -h
 
       - name: Install operator in the Kind cluster

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -175,6 +175,7 @@ jobs:
           docker rmi $(docker images -f "dangling=true" -q) || true
           docker builder prune --all -f
           go clean -modcache
+          rm -rf ${GITHUB_WORKSPACE}/cnf-certification-test-partner
           df -h
 
       - name: Install operator in the Kind cluster


### PR DESCRIPTION
This should prevent the "controller-gen" tool from "make deploy" to inspect folders that do not belong to the operator.