### PR TITLE
Github workflows: wait for cert-manager pods to be ready.

### DIFF
--- a/.github/workflows/cnfcertificationsuiterun_validation_test.yaml
+++ b/.github/workflows/cnfcertificationsuiterun_validation_test.yaml
@@ -93,7 +93,9 @@ jobs:
           command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make install
 
       - name: Install cert-manager to cluster
-        run: kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml
+        run: |
+          kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml
+          oc wait --for=condition=ready pod --all=true -n cert-manager --timeout=5m
 
       - name: More cleanup
         run: |

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -167,7 +167,9 @@ jobs:
           command: cd ${GITHUB_WORKSPACE}/cnf-certification-test-partner; make install
 
       - name: Install cert-manager to cluster
-        run: kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml
+        run: |
+          kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml
+          oc wait --for=condition=ready pod --all=true -n cert-manager --timeout=5m
 
       - name: More cleanup
         run: |


### PR DESCRIPTION
Added an "oc wait" command after the cert-manager manifests have been applied into the cluster to make sure they're ready before the operator needs to use them.

This is the failure I'm trying to avoid:
https://github.com/greyerof/tnf-op/actions/runs/8192686042/job/22404777345?pr=35
```
...
deployment.apps/cnf-certsuite-controller-manager created
validatingwebhookconfiguration.admissionregistration.k8s.io/cnf-certsuite-validating-webhook-configuration created
Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "webhook.cert-manager.io": failed to call webhook: Post "https://cert-manager-webhook.cert-manager.svc:443/validate?timeout=30s": dial tcp 10.96.52.45:443: connect: connection refused
Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "webhook.cert-manager.io": failed to call webhook: Post "https://cert-manager-webhook.cert-manager.svc:443/validate?timeout=30s": dial tcp 10.96.52.45:443: connect: connection refused
make: *** [Makefile:177: deploy] Error 1
Error: Process completed with exit code 2.
```